### PR TITLE
build and publish a wheel

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,5 +4,5 @@ set -e
 
 git push origin main
 rm -rf dist
-python setup.py sdist
+python -m build
 twine upload --skip-existing dist/* --verbose

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ flake8==7.0.0
 pylint==3.3.8
 mypy==1.9.0
 pyright==1.1.354
+build==1.3.0
 twine==5.0.0
 pandas-stubs==2.2.0.240218
 types-python-dateutil==2.8.19.20240311


### PR DESCRIPTION
Direct invocation of setup.py is deprecated.  Build and publish a wheel, as well as a source distribution.